### PR TITLE
GET ALL DATA

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,3 +29,9 @@ functions:
       - httpApi:
           path: /reception-status
           method: get
+  getAllReceptionTexts:
+    handler: src/handler.getAllReceptionTexts
+    events:
+      - httpApi:
+          path: /reception-texts
+          method: get

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
 import { ReceptionStatusTextResponse } from './types/ReceptionStatusText';
+import { AllReceptionTextsResponse } from './types/AllReceptionTexts';
 
 export const hello: APIGatewayProxyHandler = async (event) => {
   return {
@@ -38,6 +39,44 @@ export const getReceptionStatusText: APIGatewayProxyHandler = async (event) => {
         }
       },
       receptionInfo
+    };
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify(response)
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Internal Server Error' })
+    };
+  }
+};
+
+export const getAllReceptionTexts: APIGatewayProxyHandler = async (event) => {
+  try {
+    const response: AllReceptionTextsResponse = {
+      receptionStatuses: {
+        accepting: {
+          status: "受付中",
+          hours: "(4:00~23:15)",
+          isAccepting: true
+        },
+        nearEnd: {
+          status: "まもなく終了",
+          hours: "(0:00~23:15)",
+          isAccepting: true
+        },
+        closed: {
+          status: "受付時間外",
+          hours: "0:00から受付再開",
+          isAccepting: false
+        }
+      }
     };
 
     return {

--- a/src/types/AllReceptionTexts.ts
+++ b/src/types/AllReceptionTexts.ts
@@ -1,0 +1,19 @@
+export interface AllReceptionTextsResponse {
+  receptionStatuses: {
+    accepting: {
+      status: string;
+      hours: string;
+      isAccepting: boolean;
+    };
+    nearEnd: {
+      status: string;
+      hours: string;
+      isAccepting: boolean;
+    };
+    closed: {
+      status: string;
+      hours: string;
+      isAccepting: boolean;
+    };
+  };
+}


### PR DESCRIPTION
# Background

This pull request adds a new API endpoint to retrieve all possible reception status texts, alongside the necessary type definitions and handler logic. The changes ensure that clients can fetch all reception status options in a single request, improving API usability and maintainability.

**New API endpoint for all reception status texts:**

* Added a new Lambda function, `getAllReceptionTexts`, to `serverless.yml`, exposing a GET endpoint at `/reception-texts`.
* Implemented the `getAllReceptionTexts` handler in `src/handler.ts`, which returns a JSON response containing all possible reception statuses and their details.
* Defined the `AllReceptionTextsResponse` TypeScript interface in `src/types/AllReceptionTexts.ts` to type the new endpoint's response.
* Imported the new type `AllReceptionTextsResponse` in `src/handler.ts` for type safety.